### PR TITLE
[feat] 재료 Match 레시피 응답 타입 변경

### DIFF
--- a/src/main/java/com/cookrep_spring/app/controllers/recipe/RecipeController.java
+++ b/src/main/java/com/cookrep_spring/app/controllers/recipe/RecipeController.java
@@ -1,16 +1,13 @@
 package com.cookrep_spring.app.controllers.recipe;
 
 import com.cookrep_spring.app.dto.recipe.request.RecipeSearchByIngredientsRequestDTO;
-import com.cookrep_spring.app.dto.recipe.response.RecipeListResponse;
-import com.cookrep_spring.app.dto.recipe.response.RecipeListResponseDTO;
+import com.cookrep_spring.app.dto.recipe.response.*;
 import com.cookrep_spring.app.security.CustomUserDetail;
 import com.cookrep_spring.app.services.ingredient.IngredientService;
 import com.cookrep_spring.app.services.ingredient.UserIngredientService;
 import com.cookrep_spring.app.services.recipe.RecipeService;
 import com.cookrep_spring.app.utils.S3Service;
 import com.cookrep_spring.app.dto.recipe.request.RecipePostRequest;
-import com.cookrep_spring.app.dto.recipe.response.RecipeDetailResponse;
-import com.cookrep_spring.app.dto.recipe.response.RecipeUpdateResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -100,11 +97,13 @@ public class RecipeController {
      * - 반환 빈 값 "" 가능. (JS ES6에서 ""는 falsy)
      */
     @PostMapping("/search")
-    public ResponseEntity<Map<RecipeListResponseDTO, Integer>> findRecipesByIngredientIds(
-            @RequestBody RecipeSearchByIngredientsRequestDTO recipeSearchByIngredientsRequestDTO) {
+    public ResponseEntity<List<RecipeRecommendationResponseDTO>> findRecipesByIngredientIds(
+            @RequestBody RecipeSearchByIngredientsRequestDTO recipeSearchByIngredientsRequestDTO,
+            @AuthenticationPrincipal CustomUserDetail userDetails) {
         List<Integer> ingredientIds = recipeSearchByIngredientsRequestDTO.getIngredientIds();
         List<String> ingredientNames = ingredientService.findNamesByIds(ingredientIds);
-        Map<RecipeListResponseDTO, Integer> result = userIngredientService.recommendWithMatchCount(ingredientNames);
+        String userId = userDetails.getUserId();
+        List<RecipeRecommendationResponseDTO> result = recipeService.recommendWithMatchCount(ingredientNames,userId);
         return ResponseEntity.ok(result);
     }
 }

--- a/src/main/java/com/cookrep_spring/app/controllers/user/UserController.java
+++ b/src/main/java/com/cookrep_spring/app/controllers/user/UserController.java
@@ -3,15 +3,16 @@ package com.cookrep_spring.app.controllers.user;
 import com.cookrep_spring.app.dto.ingredient.request.UserIngredientAddRequestDTO;
 import com.cookrep_spring.app.dto.ingredient.response.UserIngredientAddResponseDTO;
 import com.cookrep_spring.app.dto.ingredient.response.UserIngredientResponseDTO;
-import com.cookrep_spring.app.dto.recipe.request.RecipeSearchByIngredientsRequestDTO;
 import com.cookrep_spring.app.dto.recipe.response.RecipeListResponseDTO;
 import com.cookrep_spring.app.dto.scrap.request.ScrapAddRequestDTO;
 import com.cookrep_spring.app.dto.user.request.UserUpdateRequest;
 import com.cookrep_spring.app.dto.user.response.UserDetailResponse;
 import com.cookrep_spring.app.dto.user.response.UserUpdateResponse;
 import com.cookrep_spring.app.security.CustomUserDetail;
+import com.cookrep_spring.app.utils.Util;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import com.cookrep_spring.app.services.ingredient.IngredientService;
 import com.cookrep_spring.app.services.ingredient.UserIngredientService;
 import com.cookrep_spring.app.services.scrap.ScrapService;
 import com.cookrep_spring.app.services.user.UserService;
@@ -21,7 +22,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.Map;
 
 @RestController
 @RequestMapping("/api/users")
@@ -59,9 +59,13 @@ public class UserController {
      * 유저 삭제
      */
     @DeleteMapping("/me")
-    public ResponseEntity<Void> deleteUser(@AuthenticationPrincipal CustomUserDetail userDetails) {
+    public ResponseEntity<Void> deleteUser(@AuthenticationPrincipal CustomUserDetail userDetails, HttpServletResponse response) {
         String userId = userDetails.getUserId();
         userService.deleteById(userId);
+        Cookie access = Util.buildCookie(Util.ACCESS_TOKEN, null, 0);
+        Cookie refresh = Util.buildCookie(Util.REFRESH_TOKEN, null, 0);
+        response.addCookie(access);
+        response.addCookie(refresh);
         return ResponseEntity.noContent().build();
     }
 
@@ -84,12 +88,11 @@ public class UserController {
                                                                                  @RequestBody UserIngredientAddRequestDTO ingredientAddRequestDTO) {
         String userId = userDetails.getUserId();
         String[] ingredientNames = ingredientAddRequestDTO.getIngredientNames();
+
         if (ingredientNames == null || ingredientNames.length == 0) {
             return ResponseEntity.badRequest().body(null);
         }
-        if (ingredientNames == null || ingredientNames.length == 0) {
-            return ResponseEntity.badRequest().body(null);
-        }
+
         List<UserIngredientAddResponseDTO> result = userIngredientService.addIngredients(userId, ingredientNames);
         return ResponseEntity.ok(result);
     }

--- a/src/main/java/com/cookrep_spring/app/dto/recipe/response/RecipeListResponseDTO.java
+++ b/src/main/java/com/cookrep_spring/app/dto/recipe/response/RecipeListResponseDTO.java
@@ -21,22 +21,23 @@ public class RecipeListResponseDTO {
     private int cookTime;
     private int likesCount;
     private int kcal;
-    private boolean isScrapped;
+    private boolean scrapped;
 
-    public static RecipeListResponseDTO of(Recipe recipe, boolean scrapped) {
+    public static RecipeListResponseDTO of(Recipe recipe, boolean isScrapped) {
         return RecipeListResponseDTO.builder()
-                .recipeId(recipe.getRecipeId())
-                .title(recipe.getTitle())
-                .thumbnailImageUrl(recipe.getThumbnailImageUrl())
-                .views(recipe.getViews())
-                .peopleCount(recipe.getPeopleCount())
-                .prepTime(recipe.getPrepTime())
-                .cookTime(recipe.getCookTime())
-                .likesCount(recipe.getLikesCount())
-                .kcal(recipe.getKcal())
-                .isScrapped(scrapped)
-                .build();
+                                    .recipeId(recipe.getRecipeId())
+                                    .title(recipe.getTitle())
+                                    .thumbnailImageUrl(recipe.getThumbnailImageUrl())
+                                    .views(recipe.getViews())
+                                    .peopleCount(recipe.getPeopleCount())
+                                    .prepTime(recipe.getPrepTime())
+                                    .cookTime(recipe.getCookTime())
+                                    .likesCount(recipe.getLikesCount())
+                                    .kcal(recipe.getKcal())
+                                    .scrapped(isScrapped)
+                                    .build();
     }
+
     public static RecipeListResponseDTO from(Recipe recipe) {
         return RecipeListResponseDTO.builder()
                 .recipeId(recipe.getRecipeId())
@@ -50,6 +51,7 @@ public class RecipeListResponseDTO {
                 .kcal(recipe.getKcal())
                 .build();
     }
+
     public String getCookLevel() {
         int pTime = getPrepTime();
         int cTime = getCookTime();

--- a/src/main/java/com/cookrep_spring/app/dto/recipe/response/RecipeRecommendationResponseDTO.java
+++ b/src/main/java/com/cookrep_spring/app/dto/recipe/response/RecipeRecommendationResponseDTO.java
@@ -1,0 +1,23 @@
+package com.cookrep_spring.app.dto.recipe.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class RecipeRecommendationResponseDTO {
+
+    private RecipeListResponseDTO recipe;
+    private Long matchCount;
+    private boolean scrapped;
+
+    public static RecipeRecommendationResponseDTO of(RecipeListResponseDTO recipe, Long matchCount, boolean isScrapped){
+        return RecipeRecommendationResponseDTO.builder()
+                                              .recipe(recipe)
+                                              .matchCount(matchCount)
+                                              .scrapped(isScrapped)
+                                              .build();
+    }
+}

--- a/src/main/java/com/cookrep_spring/app/services/ingredient/UserIngredientService.java
+++ b/src/main/java/com/cookrep_spring/app/services/ingredient/UserIngredientService.java
@@ -2,9 +2,6 @@ package com.cookrep_spring.app.services.ingredient;
 
 import com.cookrep_spring.app.dto.ingredient.response.UserIngredientAddResponseDTO;
 import com.cookrep_spring.app.dto.ingredient.response.UserIngredientResponseDTO;
-import com.cookrep_spring.app.dto.recipe.response.RecipeMatchDTO;
-import com.cookrep_spring.app.dto.recipe.response.RecipeListResponseDTO;
-import com.cookrep_spring.app.models.recipe.Recipe;
 import com.cookrep_spring.app.models.ingredient.Ingredient;
 import com.cookrep_spring.app.models.ingredient.UserIngredient;
 import com.cookrep_spring.app.models.ingredient.UserIngredientPK;
@@ -107,35 +104,4 @@ public class UserIngredientService {
                                        .toList();
     }
 
-    // TODO: 유저 냉장고의 재료로 레시피 검색 기능을 레시피 서비스로 이동
-    /**
-     * 냉장고 재료 기반 레시피 추천
-     * - key: RecipeListResponseDTO
-     * - value: 일치 재료 수
-     */
-    public Map<RecipeListResponseDTO, Integer> recommendWithMatchCount(List<String> ingredientNames) {
-        Map<RecipeListResponseDTO, Integer> result = new LinkedHashMap<>();
-
-        if (ingredientNames == null || ingredientNames.isEmpty()) {
-            return result; // 빈 Map 반환
-        }
-
-        List<RecipeMatchDTO> queryResult = recipeIngredientRepository.findRecipesWithMatchCount(ingredientNames);
-
-        for (RecipeMatchDTO recipeDTO : queryResult) {
-            Recipe recipe = recipeDTO.getRecipe();
-            Long matchCount = recipeDTO.getMatchCount();
-
-            String url = recipe.getThumbnailImageUrl();
-            // TODO: S3Service 구현 후 Presigned URL 생성 로직 추가 필요
-            // if (url != null && !url.startsWith("https://")) {
-            //     url = presigner.generatePresignedUrls(url);
-            // }
-
-            RecipeListResponseDTO dto = RecipeListResponseDTO.from(recipe);
-            result.put(dto, matchCount.intValue());
-        }
-
-        return result;
-    }
 }

--- a/src/main/java/com/cookrep_spring/app/services/recipe/RecipeService.java
+++ b/src/main/java/com/cookrep_spring/app/services/recipe/RecipeService.java
@@ -1,8 +1,7 @@
 package com.cookrep_spring.app.services.recipe;
 
 import com.cookrep_spring.app.dto.ingredient.response.IngredientRecipeResponse;
-import com.cookrep_spring.app.dto.recipe.response.RecipeListResponse;
-import com.cookrep_spring.app.dto.recipe.response.StepResponse;
+import com.cookrep_spring.app.dto.recipe.response.*;
 import com.cookrep_spring.app.models.ingredient.Ingredient;
 import com.cookrep_spring.app.models.ingredient.RecipeIngredient;
 import com.cookrep_spring.app.models.ingredient.RecipeIngredientPK;
@@ -14,15 +13,14 @@ import com.cookrep_spring.app.repositories.ingredient.RecipeIngredientRepository
 import com.cookrep_spring.app.repositories.recipe.RecipeRepository;
 import com.cookrep_spring.app.repositories.recipe.RecipeStepsRepository;
 import com.cookrep_spring.app.repositories.user.UserRepository;
+import com.cookrep_spring.app.services.scrap.ScrapService;
 import com.cookrep_spring.app.utils.S3Service;
 import com.cookrep_spring.app.dto.recipe.request.RecipePostRequest;
-import com.cookrep_spring.app.dto.recipe.response.RecipeDetailResponse;
-import com.cookrep_spring.app.dto.recipe.response.RecipeUpdateResponse;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import software.amazon.awssdk.services.s3.S3Client;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -38,6 +36,7 @@ public class RecipeService {
     private final S3Service s3Service;
     private final IngredientRepository ingredientRepository;
     private final RecipeIngredientRepository recipeIngredientRepository;
+    private final ScrapService scrapService;
 
     // =============== upload =================
     @Transactional
@@ -255,6 +254,45 @@ public class RecipeService {
                 .toList();
 
 
+    }
+
+    /**
+     * 냉장고 재료 기반 레시피 추천
+     * @param ingredientNames
+     * @param userId
+     * @return List<RecipeRecommendationResponseDTO>
+     */
+    public List<RecipeRecommendationResponseDTO> recommendWithMatchCount(List<String> ingredientNames, String userId) {
+        // 유저 검증
+        if (!userRepository.existsById(userId)) {
+            throw new EntityNotFoundException("유저를 찾을 수 없습니다.");
+        }
+
+        List<RecipeMatchDTO> queryResult = recipeIngredientRepository.findRecipesWithMatchCount(ingredientNames);
+
+        return queryResult
+            .stream()
+            .map(recipeMatchDTO -> {
+                Recipe recipe = recipeMatchDTO.getRecipe();
+                Long matchCount = recipeMatchDTO.getMatchCount();
+                boolean isScrapped = scrapService.isScrapped(userId, recipe.getRecipeId());
+
+                String thumbnailKey = recipe.getThumbnailImageUrl();
+                String thumbnailUrl = null;
+                if (thumbnailKey != null&&!thumbnailKey.isEmpty()) {
+                    thumbnailUrl = s3Service.generateDownloadPresignedUrls(List.of(thumbnailKey))
+                                            .get(0)
+                                            .get("downloadUrl");
+                }
+
+                // 서명된 url로 교체하여 dto 변환
+                Recipe updateRecipe = recipe.toBuilder()
+                                            .thumbnailImageUrl(thumbnailUrl)
+                                            .build();
+                RecipeListResponseDTO recipeListResponseDTO = RecipeListResponseDTO.from(updateRecipe);
+                return RecipeRecommendationResponseDTO.of(recipeListResponseDTO, matchCount, isScrapped);
+            })
+            .toList();
     }
 
     // =============== Detail =================

--- a/src/main/java/com/cookrep_spring/app/services/recipe/RecipeService.java
+++ b/src/main/java/com/cookrep_spring/app/services/recipe/RecipeService.java
@@ -279,7 +279,7 @@ public class RecipeService {
 
                 String thumbnailKey = recipe.getThumbnailImageUrl();
                 String thumbnailUrl = null;
-                if (thumbnailKey != null&&!thumbnailKey.isEmpty()) {
+                if (thumbnailKey != null && !thumbnailKey.isEmpty()) {
                     thumbnailUrl = s3Service.generateDownloadPresignedUrls(List.of(thumbnailKey))
                                             .get(0)
                                             .get("downloadUrl");


### PR DESCRIPTION
재료 Match 레시피 응답 타입 변경

## 📝 변경 사항
- 해당 기능 레시피 컨트롤러로 옮김.
- Service도 Recipe쪽으로 감.
- 응답 타입 Map->List로 변경

## 🔗 관련 이슈
Fixes #13 (Fix된 이슈를 선택합니다. #은 지우지마시고 바로 #번호 로 입력해주세요)
Closes #13 (Close할 이슈를 #은 지우지마시고 바로 #번호 로 입력해주세요)


## 🧪 테스트
- [x] 로컬 테스트 완료
- [x] 단위 테스트 작성/업데이트

## ✅ 체크리스트
- [x] 코드 리뷰 준비 완료
- [x] 문서 업데이트 (필요시)
- [x] 브레이킹 체인지 없음 (또는 명시함)
- [x] 테스트 통과

## 💬 추가 설명
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->